### PR TITLE
 FolderListの文字微調整

### DIFF
--- a/app/src/main/res/layout/activity_folder_list.xml
+++ b/app/src/main/res/layout/activity_folder_list.xml
@@ -68,9 +68,9 @@
     <!--登録がなかった時のメッセージを配置 真ん中に配置　centerInParentのみで設定できる-->
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/nothing_message"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_marginTop="150dp"
         android:gravity="center"
         android:text="@string/nothing_message"
         android:textColor="@color/colorAnnotation"


### PR DESCRIPTION
報告会で、データがない場合の文字表示が背景の画像と被ってしまうとご指摘をいただいたので、修正しました。