### PR TITLE
端末再起動時に金額が２倍になる問題を解決

### DIFF
--- a/app/src/main/java/com/example/driveandroid/FolderDetailActivity.kt
+++ b/app/src/main/java/com/example/driveandroid/FolderDetailActivity.kt
@@ -54,6 +54,12 @@ class FolderDetailActivity : AppCompatActivity() {
         paraCostArray.clear()
     }
 
+    //端末を再起動した際
+    override fun onRestart() {
+        super.onRestart()
+        paraCostArray.clear()
+    }
+
     //Resume処理
     override fun onResume() {
         super.onResume()


### PR DESCRIPTION
端末の画面が暗くなってまた起動する際に金額が２倍になってしまう問題が発生したので
その点を修正しました。